### PR TITLE
Calcula prazo do rastreio em background quando importa a nota

### DIFF
--- a/modules/Core/app/Http/Controllers/Partials/UploadController.php
+++ b/modules/Core/app/Http/Controllers/Partials/UploadController.php
@@ -471,11 +471,6 @@ class UploadController extends Controller
             $dataEnvio = $dataEnvio->format('Y-m-d');
 
             /**
-             * Calcula prazo
-             */
-            $prazoEntrega = RastreioController::deadline($rastreio, $this->nfe->dest->enderDest->CEP);
-
-            /**
              * Salva o rastreio
              */
 
@@ -490,7 +485,7 @@ class UploadController extends Controller
             $pedidoRastreio->data_envio = $dataEnvio;
             $pedidoRastreio->servico = $metodoEnvio;
             $pedidoRastreio->valor = $freteTotal;
-            $pedidoRastreio->prazo = $prazoEntrega;
+            $pedidoRastreio->prazo = null;
 
             if ($pedidoRastreio->save()) {
                 Log::info('Rastreio importado ' . $pedidoRastreio->id);

--- a/modules/Rastreio/app/Events/Handlers/AddRastreioToQueue.php
+++ b/modules/Rastreio/app/Events/Handlers/AddRastreioToQueue.php
@@ -1,9 +1,12 @@
 <?php namespace Rastreio\Events\Handlers;
 
+use Core\Events\OrderSent;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Facades\Log;
 use Rastreio\Events\RastreioSaved;
 use Rastreio\Jobs\GetScreenshot;
+use Rastreio\Jobs\SetDeadline;
+use Rastreio\Models\Rastreio;
 
 class AddRastreioToQueue
 {
@@ -18,6 +21,11 @@ class AddRastreioToQueue
         $events->listen(
             RastreioSaved::class,
             '\Rastreio\Events\Handlers\AddRastreioToQueue@onRastreioSaved'
+        );
+
+        $events->listen(
+            OrderSent::class,
+            '\Rastreio\Events\Handlers\AddRastreioToQueue@onOrderSent'
         );
     }
 
@@ -37,6 +45,23 @@ class AddRastreioToQueue
 
         if ($newStatus !== $oldStatus && in_array($newStatus, [3, 4, 5, 6])) {
             dispatch(with(new GetScreenshot($rastreio))->onQueue('low'));
+        }
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  onOrderSent  $event
+     * @return void
+     */
+    public function onOrderSent(OrderSent $event)
+    {
+        $order = $event->order;
+        $rastreio = (isset($order->rastreios[0])) ? $order->rastreios[0] : null;
+
+        if (!is_null($rastreio)) {
+            Log::debug('Handler AddRastreioToQueue/onOrderSent acionado!', [$event]);
+            dispatch(with(new SetDeadline($rastreio))->onQueue('medium'));
         }
     }
 }

--- a/modules/Rastreio/app/Jobs/SetDeadline.php
+++ b/modules/Rastreio/app/Jobs/SetDeadline.php
@@ -1,0 +1,50 @@
+<?php namespace Rastreio\Jobs;
+
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Rastreio\Http\Controllers\RastreioController;
+use Rastreio\Models\Rastreio;
+
+class SetDeadline implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $rastreio;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Rastreio $rastreio)
+    {
+        \Log::debug('Job Rastreio\SetDeadline criado', [$rastreio]);
+        $this->rastreio = $rastreio;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        \Log::debug('Job Rastreio\SetDeadline executado', [$this->rastreio]);
+        with(new RastreioController())->setDeadline($this->rastreio);
+    }
+
+    /**
+     * The job failed to process.
+     *
+     * @param  Exception  $exception
+     * @return void
+     */
+    public function failed(Exception $exception)
+    {
+        # TODO: enviar notificacao
+        \Log::critical(logMessage($exception, 'Erro ao executar Job Rastreio\SetDeadline'), [$this->rastreio]);
+    }
+}

--- a/modules/Rastreio/app/Models/Rastreio.php
+++ b/modules/Rastreio/app/Models/Rastreio.php
@@ -181,4 +181,14 @@ class Rastreio extends \Eloquent
     {
         return !!$this->monitoramentos()->where('usuario_id', '=', getCurrentUserId())->first();
     }
+
+    /**
+     * Retorna o cep do endereço do pedido
+     *
+     * @return int|string
+     */
+    public function getCep()
+    {
+        return $this->pedido->endereco->cep;
+    }
 }


### PR DESCRIPTION
Fixes #46 

Skyhub continua usando o metodo deadline
Upload de nota não faz nada a respeito do prazo do rastreio

Quando o pedido passa para enviado, um Job é acionado, calculando o prazo de entrega por meio dos correios.