### PR TITLE
Arruma bug ao atualizar estoque na cricao de um produto do pedido

### DIFF
--- a/modules/Core/app/Http/Controllers/Partials/UploadController.php
+++ b/modules/Core/app/Http/Controllers/Partials/UploadController.php
@@ -596,7 +596,8 @@ class UploadController extends Controller
                 if (!$pedidoProduto) {
                     $pedidoProduto = PedidoProduto::create([
                         'pedido_id' => $pedido->id,
-                        'produto_sku' => $produto->sku
+                        'produto_sku' => $produto->sku,
+                        'quantidade' => $item['quantidade']
                     ]);
                 }
 


### PR DESCRIPTION
fixes #53 

O erro acontecia por que quando um pedido produto tentava ser criado ao fazer o upload da nota, nenhuma quantidade era atribuída a ele.