### PR TITLE
Mudanca na regra de cancelamento de pedidos do magento

### DIFF
--- a/modules/Core/app/Http/Controllers/Pedido/PedidoController.php
+++ b/modules/Core/app/Http/Controllers/Pedido/PedidoController.php
@@ -236,9 +236,12 @@ class PedidoController extends Controller
                 $dataPedido = Carbon::createFromFormat('d/m/Y H:i', $pedido->created_at)->format('d/m/Y');
                 $diasUteis = diasUteisPeriodo($dataPedido, date('d/m/Y'), true);
 
-                if (strtolower($pedido->marketplace) == 'site' && $diasUteis > Config::get('magento.old_order')) {
-                    $pedido->status = 5;
-                    $pedido->save();
+                if (strtolower($pedido->marketplace) == 'site') {
+                    if (($pedido->pagamento_metodo == 'boleto' && $diasUteis > Config::get('magento.old_order.boleto'))
+                        || ($pedido->pagamento_metodo == 'credito' && $diasUteis > Config::get('magento.old_order.credito'))) {
+                        $pedido->status = 5;
+                        $pedido->save();
+                    }
                 }
             } catch (\Exception $e) {
                 Log::error(logMessage($e, 'Não foi possível cancelar o pedido na Integração'));

--- a/modules/Magento/config/config.php
+++ b/modules/Magento/config/config.php
@@ -8,7 +8,10 @@ return [
         'user' => env('MAGENTO_API_USER', 'carioca'),
         'key'  => env('MAGENTO_API_KEY', '#@carioca2016')
     ],
-    'old_order' => 4,
+    'old_order' => [
+        'boleto'  => 5,
+        'credito' => 2
+    ],
 
     /**
      * Micro-serviços


### PR DESCRIPTION
Fixes #38 

Foi criado uma config para pedidos de boleto e de cartão de crédito, definindo o cancelamento automático de boletos em 5 dias, e de cartão de crédito em 2. Ambos valem para dias úteis.