### PR TITLE
Paginas de erro customizadas

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -54,6 +54,13 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
+        // custom errors views
+        if ($exception instanceof ModelNotFoundException || $exception instanceof NotFoundHttpException) {
+            return response()->view('errors.404', [], 404);
+        } elseif (!env('APP_DEBUG')) {
+            return response()->view('errors.500', [], 500);
+        }
+
         return parent::render($request, $exception);
     }
 

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html ng-app="MeuTucano" ng-cloak>
+    <head lang="pt">
+        <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+        <meta name="robots" content="noindex, nofollow" />
+
+        <title>Meu Tucano - Manutenção</title>
+
+        <link rel="stylesheet" href="{{ Cdn::asset('assets/css/app.min.css') }}" />
+
+        <link rel="icon" type="image/x-icon" href="{{ Cdn::asset('assets/img/favicon.ico') }}" />
+    </head>
+
+    <body class="fixed-header error-page">
+        <div class="container-xs-height full-height">
+            <div class="row-xs-height">
+                <div class="col-xs-height col-middle">
+                    <div class="error-container text-center">
+                        <h1 class="error-number"><img src="{{ Cdn::asset('assets/img/logo-image.png') }}" alt="MeuTucano"></h1>
+                        <h2 class="semi-bold">Estamos em manutenção!</h2>
+                        <p>Voltaremos em breve, aguarde alguns minutos e atualize a página!</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html ng-app="MeuTucano" ng-cloak>
+    <head lang="pt">
+        <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+        <meta name="robots" content="noindex, nofollow" />
+
+        <title>Meu Tucano - Manutenção</title>
+
+        <link rel="stylesheet" href="{{ Cdn::asset('assets/css/app.min.css') }}" />
+
+        <link rel="icon" type="image/x-icon" href="{{ Cdn::asset('assets/img/favicon.ico') }}" />
+    </head>
+
+    <body class="fixed-header error-page">
+        <div class="container-xs-height full-height">
+            <div class="row-xs-height">
+                <div class="col-xs-height col-middle">
+                    <div class="error-container text-center">
+                        <h1 class="error-number"><img src="{{ Cdn::asset('assets/img/logo-image.png') }}" alt="MeuTucano"></h1>
+                        <h2 class="semi-bold">Estamos em manutenção!</h2>
+                        <p>Voltaremos em breve, aguarde alguns minutos e atualize a página!</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Fixes #28 

View de erro 404 e 500.
A 404 é invocada quando as exceções ModelNotFoundException e NotFoundHttpException são lançadas.

As duas páginas são iguais visualmente por enquanto, nelas tem uma frase dizendo que o tucano está em manutenção.